### PR TITLE
Add userID Reference to Work History and Education Schemas

### DIFF
--- a/models/Education.js
+++ b/models/Education.js
@@ -1,36 +1,44 @@
 import mongoose from "mongoose";
 
-const educationSchema = new mongoose.Schema({
-  degree: {
-    type: String,
-    required: true,
-    trim: true,
+const educationSchema = new mongoose.Schema(
+  {
+    userID: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "Users",
+      required: [true, "User ID is required"],
+    },
+    degree: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    institution: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    startDate: {
+      type: Date,
+      required: true,
+    },
+    endDate: {
+      type: Date,
+    },
+    fieldOfStudy: {
+      type: String,
+      trim: true,
+    },
+    description: {
+      type: String,
+      trim: true,
+    },
+    currentlyStudying: {
+      type: Boolean,
+      default: false,
+    },
   },
-  institution: {
-    type: String,
-    required: true,
-    trim: true,
-  },
-  startDate: {
-    type: Date,
-    required: true,
-  },
-  endDate: {
-    type: Date,
-  },
-  fieldOfStudy: {
-    type: String,
-    trim: true,
-  },
-  description: {
-    type: String,
-    trim: true,
-  },
-  currentlyStudying: {
-    type: Boolean,
-    default: false,
-  },
-}, { timestamps: true });
+  { timestamps: true }
+);
 
 const Education = mongoose.model("Education", educationSchema);
 export default Education;

--- a/models/Work.js
+++ b/models/Work.js
@@ -2,6 +2,11 @@ import mongoose from "mongoose";
 
 const workHistorySchema = new mongoose.Schema(
   {
+    userID: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "Users",
+      required: [true, "User ID is required"],
+    },
     jobTitle: {
       type: String,
       required: true,


### PR DESCRIPTION
This pull request introduces the `userID` reference to the Work History and Education schemas:

- Added `userID` field to both schemas to associate records with specific users.
- Applied validation to ensure `userID` is provided and correctly referenced.
- Maintained existing fields and validation rules.

This update strengthens the link between user records and their associated work history and education, improving data consistency.
